### PR TITLE
Feature to configure dalek backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Build
       run: cargo build
     - name: Build no_std
-      run: cd bamboo-rs-core && cargo build --no-default-features
+      run: cd bamboo-rs-core && cargo build --no-default-features --features u64_backend
     - name: Run tests
       run: cargo test
     - name: Run benches

--- a/bamboo-c/Cargo.toml
+++ b/bamboo-c/Cargo.toml
@@ -9,9 +9,11 @@ name = "bamboo_c"
 crate-type = ["cdylib", "staticlib"]
 
 [features]
-default = ["std"]
+default = ["std", "u64_backend"]
 std = ["ed25519-dalek/std"]
+u32_backend = ["bamboo-rs-core/u32_backend", "ed25519-dalek/u32_backend"]
+u64_backend = ["bamboo-rs-core/u64_backend", "ed25519-dalek/u64_backend"]
 
 [dependencies]
-bamboo-rs-core = {path = "../bamboo-rs-core", default_features = false, features = ["u64_backend"]}
-ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend"] }
+bamboo-rs-core = {path = "../bamboo-rs-core", default_features = false}
+ed25519-dalek = { version = "1.0.1", default-features = false}

--- a/bamboo-c/Cargo.toml
+++ b/bamboo-c/Cargo.toml
@@ -13,5 +13,5 @@ default = ["std"]
 std = ["ed25519-dalek/std"]
 
 [dependencies]
-bamboo-rs-core = {path = "../bamboo-rs-core", default_features = false}
+bamboo-rs-core = {path = "../bamboo-rs-core", default_features = false, features = ["u64_backend"]}
 ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend"] }

--- a/bamboo-rs-core/CHANGELOG.md
+++ b/bamboo-rs-core/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-pre-31] - 2021-2-8
+### Added
+- Features `u32_backend` and `u64_backend` that configures `ed25519-dalek`.
+
 ## [0.1.0-pre-30] - 2021-1-17
 ### Changed
 - change api of publish to take &Keypair, not Option<&Keypair>

--- a/bamboo-rs-core/Cargo.toml
+++ b/bamboo-rs-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bamboo-rs-core"
-version = "0.1.0-pre-29"
+version = "0.1.0-pre-31"
 authors = ["Piet Geursen <pietgeursen@gmail.com>"]
 edition = "2018"
 license = "AGPL-3.0"

--- a/bamboo-rs-core/Cargo.toml
+++ b/bamboo-rs-core/Cargo.toml
@@ -8,13 +8,15 @@ repository = "https://github.com/pietgeursen/bamboo-rs"
 description = "Publish and verify signed hash chains of bamboo messages."
 
 [features]
-default = ["std"]
+default = ["std", "u64_backend"]
 std = ["varu64/std", "hex/std", "rayon", "snafu/std", "ed25519-dalek/serde", "ed25519-dalek/std", "ed25519-dalek/batch", "yamf-hash/std"]
+u64_backend = ["ed25519-dalek/u64_backend"]
+u32_backend = ["ed25519-dalek/u32_backend"]
 
 [dependencies]
 arrayvec = { version = "0.5.1", default-features = false}
 blake2b_simd = { version = "0.5", default-features = false }
-ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend"] }
+ed25519-dalek = { version = "1.0.1", default-features = false }
 hex = { version = "0.4", default-features = false }
 lipmaa-link = "0.1"
 rayon = { version = "1.5", optional = true }

--- a/bamboo-wasm/Cargo.toml
+++ b/bamboo-wasm/Cargo.toml
@@ -11,6 +11,9 @@ wasm-opt = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
+
+# I'd rather set the default to be u32_backend but if we do that then building from the workspace level breaks. 
+# Use the u32_backend feature when actually building for wasm.
 default = ["u64_backend"]
 u32_backend = ["base", "bamboo-rs-core/u32_backend", "ed25519-dalek/u32_backend"]
 u64_backend = ["base", "bamboo-rs-core/u64_backend", "ed25519-dalek/u64_backend"]

--- a/bamboo-wasm/Cargo.toml
+++ b/bamboo-wasm/Cargo.toml
@@ -11,14 +11,16 @@ wasm-opt = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["wee_alloc", "console_error_panic_hook"]
-
+default = ["u64_backend"]
+u32_backend = ["base", "bamboo-rs-core/u32_backend", "ed25519-dalek/u32_backend"]
+u64_backend = ["base", "bamboo-rs-core/u64_backend", "ed25519-dalek/u64_backend"]
+base = ["wee_alloc", "console_error_panic_hook"]
 
 [dependencies]
 arrayvec = { version = "0.5", default-features = false}
 wasm-bindgen = { version = "0.2.69"}
-bamboo-rs-core = {path = "../bamboo-rs-core"}
-ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend", "alloc", "serde"] }
+bamboo-rs-core = {path = "../bamboo-rs-core", default-features = false, features = ["std"]}
+ed25519-dalek = { version = "1.0.1", default-features = false, features = ["alloc", "serde"] }
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/bamboo-wasm/README.md
+++ b/bamboo-wasm/README.md
@@ -73,7 +73,8 @@ See the Typescript types in `index.d.ts`
 ### 🛠️ Build with `wasm-pack build`
 
 ```
-wasm-pack build  -t nodejs --scope bamboo-logs --release --out-name index
+wasm-pack build  -t nodejs --scope bamboo-logs --release --out-name index -- --no-default-features --features u32_backend
+wasm-opt index_bg.wasm --enable-mutable-globals -O4 -o ./index_bg.wasm
 ```
 
 ### 🔬 Test in Headless Browsers with `wasm-pack test`

--- a/ci/build.bash
+++ b/ci/build.bash
@@ -22,14 +22,14 @@ if [ -z "$RELEASE_BUILD" ]; then
       $CROSS build --target $TARGET_TRIPLE
       $CROSS build --target $TARGET_TRIPLE --all-features
     else
-      $CROSS build -p bamboo-c --target $TARGET_TRIPLE --no-default-features --manifest-path=bamboo-c/Cargo.toml
+      $CROSS build -p bamboo-c --target $TARGET_TRIPLE --no-default-features --features u32_backend --manifest-path=bamboo-c/Cargo.toml
     fi
 else
     if [ -z $NO_STD ]
     then
       $CROSS build --target $TARGET_TRIPLE --all-features --release
     else
-      $CROSS build -p bamboo-c --target $TARGET_TRIPLE --no-default-features --manifest-path=bamboo-c/Cargo.toml --release
+      $CROSS build -p bamboo-c --target $TARGET_TRIPLE --no-default-features --features u32_backend --manifest-path=bamboo-c/Cargo.toml --release
     fi
 fi
 


### PR DESCRIPTION
Considerably decreases binary sizes for 32bit targets. Wasm build goes from 237k to 189k. :tada: 